### PR TITLE
feat: bump release status to GA

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/iot",
   "client_documentation": "https://googleapis.dev/python/cloudiot/latest",
   "issue_tracker": "https://issuetracker.google.com/issues?q=status:open%20componentid:310170",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-iot",
   "distribution_name": "google-cloud-iot",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Client for Cloud IoT API
 ===============================
 
-|alpha| |pypi| |versions| 
+|GA| |pypi| |versions| 
 
 `Cloud IoT API`_: Registers and manages IoT (Internet of Things) devices that
 connect to the Google Cloud Platform.
@@ -9,8 +9,8 @@ connect to the Google Cloud Platform.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg
    :target: https://pypi.org/project/google-cloud-iot/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iot.svg

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 name = "google-cloud-iot"
 description = "Cloud IoT API API client library"
 version = "0.3.1"
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",


### PR DESCRIPTION
Release-As: 1.0.0


[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
