### PR TITLE
fix: fix extras_require typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     packages=packages,
     namespace_packages=namespaces,
     install_requires=dependencies,
-    extras_requires=extras,
+    extras_require=extras,
     python_requires=">=3.6",
     scripts=["scripts/fixup_iot_v1_keywords.py"],
     include_package_data=True,


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/userguide/dependency_management.html?highlight=extras_require#optional-dependencies
