### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudiot",
     "name_pretty": "Google Cloud Internet of Things (IoT) Core",
     "product_documentation": "https://cloud.google.com/iot",
-    "client_documentation": "https://googleapis.dev/python/cloudiot/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudiot/latest",
     "issue_tracker": "https://issuetracker.google.com/issues?q=status:open%20componentid:310170",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ connect to the Google Cloud Platform.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iot.svg
    :target: https://pypi.org/project/google-cloud-iot/
 .. _Cloud IoT API: https://cloud.google.com/iot
-.. _Client Library Documentation: https://googleapis.dev/python/cloudiot/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudiot/latest
 .. _Product Documentation:  https://cloud.google.com/iot
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.