### PR TITLE
chore(deps): allow google-api-core v2 on v1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ description = "Cloud IoT API API client library"
 version = "1.0.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566